### PR TITLE
Outputting error to console.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coppa",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "🏇 A CLI tool for local development of google cloud functions",
   "main": "src/cli.js",
   "author": "Jason Rametta <rametta@outlook.com>",

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,7 +13,7 @@ const { Ok, Err, encaseRes } = require('pratica')
 
 const readServerlessYaml = (filePath, stage) =>
   encaseRes(() => yaml.safeLoad(fs.readFileSync(filePath, 'utf8')))
-    .mapErr(() => `Error reading yaml file: ${filePath}`)
+    .mapErr(err => `Error reading yaml file: ${filePath}, \nError: ${err}`)
     .chain(yml => yml.functions ? Ok(yml) : Err(`No functions declared in yaml file: ${config}`))
     .map(({ functions, service }) => Object.keys(functions).map(key => ({
       name: stage ? `/${service}-${stage}-${key}` : `/${service}-${key}`,
@@ -24,7 +24,7 @@ const readServerlessYaml = (filePath, stage) =>
 
 const readFunctionsJs = filePath =>
   encaseRes(() => require(path.resolve(filePath)))
-    .mapErr(() => `Could not read main functions module: ${filePath}`)
+    .mapErr(err => `Could not read main functions module: ${filePath}, \nError: ${err}`)
 
 const sanitizeFuncs = ({ handlers, funcsMod }) => handlers
   .map(({ name, display, description, handler }) => ({ name, display, description, handler: funcsMod[handler] }))


### PR DESCRIPTION
Tryig to determine the error when coppa fails to run was quite painful. Outbutting the error makes it very easy to determine what is going wrong.

Incremented the package version.


<img width="1071" alt="Screen Shot 2019-07-15 at 10 11 25 AM" src="https://user-images.githubusercontent.com/37623247/61222788-64307980-a6e9-11e9-8f57-a0a70b9aec71.png">
<img width="572" alt="Screen Shot 2019-07-15 at 10 10 47 AM" src="https://user-images.githubusercontent.com/37623247/61222789-64307980-a6e9-11e9-899d-d7bdb29a28ae.png">
