### PR TITLE
fixed nested routing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -37,7 +37,7 @@ const createServer = port => funcs => {
   app.use(morgan('dev'))
   app.use(cors())
 
-  funcs.map(({ name, handler }) => console.log(name) || app.all(name, handler))
+  funcs.map(({ name, handler }) => console.log(name) || app.use(name, handler))
 
   app.get('/', (req, res) => quantor({
     title: 'Coppa Server',


### PR DESCRIPTION
* app.all don't support child routes; it forces to use only one route ie /${service}-${stage}-${key}
* app.use support child route and it matches routes by matching string that it starts with
* app.use is also good if you are not using express; as it works as expected