### PR TITLE
Allow the display name to be used as the route

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -37,7 +37,7 @@ const createServer = port => funcs => {
   app.use(morgan('dev'))
   app.use(cors())
 
-  funcs.map(({ name, handler }) => console.log(name) || app.use(name, handler))
+  funcs.map(({ name, handler, display }) => console.log(display ? `/${display}` : name) || app.use(display ? `/${display}` : name, handler))
 
   app.get('/', (req, res) => quantor({
     title: 'Coppa Server',


### PR DESCRIPTION
This allows the `name` override in the `serverless.yml` to be reflected in the api routes, so it doesn't automatically append the `api-` prefix if there is a name override specified.